### PR TITLE
Fix: Remove instructional note from CHANGES section templates

### DIFF
--- a/.github/prompts/6-generate-changelog.md
+++ b/.github/prompts/6-generate-changelog.md
@@ -23,8 +23,6 @@ The CHANGES section MUST follow this exact structure:
 ```markdown
 ## CHANGES for vX.Y.Z Release
 
-**Note:** This section must follow the format specified in `features/CHANGES-TEMPLATE.md`. The content will be posted as the closing comment and consumed by the release workflow.
-
 Issue #XX: Issue Title
 
 ### Issues Closed

--- a/features/ISSUE-PLAN-TEMPLATE.md
+++ b/features/ISSUE-PLAN-TEMPLATE.md
@@ -371,8 +371,6 @@ After completing Steps 1-N, comprehensive testing revealed [X] test failures tha
 
 ## CHANGES for vX.X.X Release
 
-**Note:** This section must follow the format specified in `features/CHANGES-TEMPLATE.md`. The content will be posted as the closing comment and consumed by the release workflow.
-
 Issue #[NUMBER]: [Issue Title]
 
 ### Issues Closed


### PR DESCRIPTION
Fixes #84

## Problem

The CHANGES section template included an instructional note meant for AI agents that was appearing in actual release notes.

## Changes

Removed the note from:
- `.github/prompts/6-generate-changelog.md`
- `features/ISSUE-PLAN-TEMPLATE.md`

Existing plan documents (issue-15, issue-61) left unchanged as historical records.

## Testing

Future plan documents generated with these templates will no longer include the instructional note in their CHANGES sections.